### PR TITLE
fix: recursively read folder entries because most browsers only return the first 100 entries

### DIFF
--- a/ember-file-upload/src/test-support.ts
+++ b/ember-file-upload/src/test-support.ts
@@ -126,7 +126,8 @@ export async function dragAndDropDirectory(
       name: folderName,
       createReader: () => ({
         readEntries: (callback: (entries: FileSystemEntryStub[]) => void) => {
-          const entryFiles = filesInDirectory.map((file) => {
+          const readingFiles = filesInDirectory.splice(0, 2);
+          const entryFiles = readingFiles.map((file) => {
             return {
               isFile: true,
               file: (callback: (file: File | Blob) => void) => {

--- a/test-app/tests/unit/system/data-transfer-wrapper-test.js
+++ b/test-app/tests/unit/system/data-transfer-wrapper-test.js
@@ -62,9 +62,17 @@ module('Unit | DataTransferWrapper', function (hooks) {
           name: 'zoey.png',
           type: 'image/png',
         },
+        {
+          name: 'tomster.jpg',
+          type: 'image/jpeg',
+        },
+        {
+          name: 'zoey.png',
+          type: 'image/png',
+        },
       ],
     };
-    assert.strictEqual(this.subject.filesOrItems.length, 2);
+    assert.strictEqual(this.subject.filesOrItems.length, 4);
   });
 
   test('directory dropped', async function (assert) {
@@ -85,7 +93,8 @@ module('Unit | DataTransferWrapper', function (hooks) {
       isDirectory: true,
       createReader: () => ({
         readEntries: (callback) => {
-          const entryFiles = filesInDirectory.map((file) => {
+          const readingFiles = filesInDirectory.splice(0, 2)
+          const entryFiles = readingFiles.map((file) => {
             return {
               isFile: true,
               file: (callback) => {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryReader/readEntries


<img width="826" alt="image" src="https://github.com/user-attachments/assets/ba746a2e-3bbd-4da1-bb84-0cb7d5f29008">


Using a recursive function which only resolves when the new readEntries array is empty, which is more in line with the spec.
